### PR TITLE
Bumped Ayza to 10.0.5

### DIFF
--- a/sdmx-dl-provider-ri/pom.xml
+++ b/sdmx-dl-provider-ri/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>io.github.hakky54</groupId>
             <artifactId>ayza</artifactId>
-            <version>10.0.4</version>
+            <version>10.0.5</version>
         </dependency>
         <dependency>
             <groupId>com.github.nbbrd.java-net-proxy</groupId>

--- a/sdmx-dl-standalone/src/test/java/spreadsheet4j/standalone/RuntimeDependenciesTest.java
+++ b/sdmx-dl-standalone/src/test/java/spreadsheet4j/standalone/RuntimeDependenciesTest.java
@@ -25,11 +25,11 @@ public class RuntimeDependenciesTest {
                 .satisfies(RuntimeDependenciesTest::checkPicocsv)
                 .satisfies(RuntimeDependenciesTest::checkPowershell)
                 .satisfies(RuntimeDependenciesTest::checkGson)
-                .satisfies(RuntimeDependenciesTest::checkSllContextKickstart)
+                .satisfies(RuntimeDependenciesTest::checkAyza)
                 .satisfies(RuntimeDependenciesTest::checkJavaNetProxy)
                 .satisfies(RuntimeDependenciesTest::checkKryo5)
                 .satisfies(RuntimeDependenciesTest::checkMsal)
-                .hasSize(25);
+                .hasSize(27);
     }
 
     private static void checkJavaIoUtil(List<? extends DependencyResolver.GAV> coordinates) {
@@ -86,10 +86,10 @@ public class RuntimeDependenciesTest {
                 .containsExactlyInAnyOrder("gson");
     }
 
-    private static void checkSllContextKickstart(List<? extends DependencyResolver.GAV> coordinates) {
+    private static void checkAyza(List<? extends DependencyResolver.GAV> coordinates) {
         assertThatGroupId(coordinates, "io.github.hakky54")
                 .extracting(DependencyResolver.GAV::getArtifactId)
-                .containsExactlyInAnyOrder("ayza", "sude");
+                .containsExactlyInAnyOrder("ayza", "sude", "laleler", "desidero");
     }
 
     private static void checkJavaNetProxy(List<? extends DependencyResolver.GAV> coordinates) {


### PR DESCRIPTION
I remembered in the past you did a runtime check on transitive dependencies on libraries for this project. 

I recently extracted internal utilities into separate java libraries to reduce the complexity of the Ayza library and to improve the reusability of it which resulted into additional transitive dependencies.

The related work can be found here: https://github.com/Hakky54/ayza/pull/742 and https://github.com/Hakky54/ayza/pull/743

It is still backwords compatible, no changes to the end-user actually. But I was expecting your test to fail as it is checking the transitive dependencies, so I wanted to submit this PR

